### PR TITLE
Add support for authentication API v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ User need to provide following parameters in configuration for collector:
 - `"tenant"` - name of the tenant, this is required if not provided in global config
 - `"user"` -  user name which has access to tenant
 - `"password"` - user password
+If you're using authentication API in v3 you need to set one of those two configuration options:
+- `"domain_name"` - domain name
+- `"domain_id"` - domain name
 
 See example task manifest in [examples/task] (examples/tasks/task.json).
 

--- a/openstack/common.go
+++ b/openstack/common.go
@@ -50,7 +50,7 @@ type Common struct{}
 func (c Common) GetTenants(endpoint, user, password string) ([]types.Tenant, error) {
 	tnts := []types.Tenant{}
 
-	provider, err := Authenticate(endpoint, user, password, "")
+	provider, err := Authenticate(endpoint, user, password, "", "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -108,13 +108,19 @@ func (c Common) GetApiVersions(provider *gophercloud.ProviderClient) ([]types.Ap
 
 // Authenticate is used to authenticate user for given tenant. Request is send to provided Keystone endpoint
 // Returns authenticated provider client, which is used as a base for service clients.
-func Authenticate(endpoint, user, password, tenant string) (*gophercloud.ProviderClient, error) {
+func Authenticate(endpoint, user, password, tenant, domain_name, domain_id string) (*gophercloud.ProviderClient, error) {
 	authOpts := gophercloud.AuthOptions{
 		IdentityEndpoint: endpoint,
 		Username:         user,
 		Password:         password,
 		TenantName:       tenant,
 		AllowReauth:      true,
+	}
+	if domain_name != "" && domain_id == "" {
+		authOpts.DomainName = domain_name
+	}
+	if domain_id != "" && domain_name == "" {
+		authOpts.DomainID = domain_id
 	}
 
 	provider, err := openstack.AuthenticatedClient(authOpts)

--- a/openstack/common_test.go
+++ b/openstack/common_test.go
@@ -68,7 +68,7 @@ func (s *CommonSuite) TestGetAPI() {
 	Convey("Given api versions are requested", s.T(), func() {
 		c := Common{}
 		Convey("When GetAPIVersions is called", func() {
-			provider, err := Authenticate(th.Endpoint(), "me", "secret", "tenant")
+			provider, err := Authenticate(th.Endpoint(), "me", "secret", "tenant", "", "")
 			th.AssertNoErr(s.T(), err)
 			th.CheckEquals(s.T(), s.Token, provider.TokenID)
 

--- a/openstack/v1/glance/glance_test.go
+++ b/openstack/v1/glance/glance_test.go
@@ -56,7 +56,7 @@ func (s *GlanceV1Suite) TestGetImages() {
 	Convey("Given Glance images are requested", s.T(), func() {
 
 		Convey("When authentication is required", func() {
-			provider, err := openstackintel.Authenticate(th.Endpoint(), "me", "secret", "tenant")
+			provider, err := openstackintel.Authenticate(th.Endpoint(), "me", "secret", "tenant", "", "")
 			th.AssertNoErr(s.T(), err)
 			th.CheckEquals(s.T(), s.Token, provider.TokenID)
 

--- a/openstack/v2/glance/glance_test.go
+++ b/openstack/v2/glance/glance_test.go
@@ -56,7 +56,7 @@ func (s *GlanceV2Suite) TestGetImages() {
 	Convey("Given Glance images are requested", s.T(), func() {
 
 		Convey("When authentication is required", func() {
-			provider, err := openstackintel.Authenticate(th.Endpoint(), "me", "secret", "tenant")
+			provider, err := openstackintel.Authenticate(th.Endpoint(), "me", "secret", "tenant", "", "")
 			th.AssertNoErr(s.T(), err)
 			th.CheckEquals(s.T(), s.Token, provider.TokenID)
 


### PR DESCRIPTION
Add support for authentication API v3
- add support for domain_name and domain_id configuration options
- fix for #19 

Signed-off-by: Patryk Matyjasek <patryk.matyjasek@intel.com>
